### PR TITLE
fix: Makefile's install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,18 +42,17 @@ clean:
 	rm -rf build
 
 
-install-icons:
+install:
 	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/bloom
 	cp -r bloom/* $(DESTDIR)$(PREFIX)/share/icons/bloom
 	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/bloom-dark
 	cp -r bloom-dark/* $(DESTDIR)$(PREFIX)/share/icons/bloom-dark
 	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/Vintage
 	cp -r Vintage/* $(DESTDIR)$(PREFIX)/share/icons/Vintage
-
-install-cursors:
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/bloom
-	cp -r bloom/cursors $(DESTDIR)$(PREFIX)/share/icons/bloom
-	install -m644 bloom/cursor.theme $(DESTDIR)$(PREFIX)/share/icons/bloom/cursor.theme
+	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/bloom-classic
+	cp -r bloom-classic/* $(DESTDIR)$(PREFIX)/share/icons/bloom-classic
+	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/bloom-classic-dark
+	cp -r bloom-classic-dark/* $(DESTDIR)$(PREFIX)/share/icons/bloom-classic-dark
 
 hicolor-links:
 	./tools/hicolor.links bloom hicolor.list ./


### PR DESCRIPTION
bloom-v20 is gone and install-cursors is included in the install-icons target, so better just merge them.