### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,17 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/deepin-icon-theme.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/deepin-icon-theme.spec
+    - .packit.yaml
+
+upstream_package_name: deepin-icon-theme
+# downstream (Fedora) RPM package name
+downstream_package_name: deepin-icon-theme
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"0,/Version:/ s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/deepin-icon-theme.spec"

--- a/rpm/deepin-icon-theme.spec
+++ b/rpm/deepin-icon-theme.spec
@@ -1,0 +1,74 @@
+%global themes bloom bloom-dark bloom-classic bloom-classic-dark Sea
+%global start_logo start-here
+
+Name:           deepin-icon-theme
+Version:        2020.09.25
+Release:        1%{?dist}
+Summary:        Icons for the Deepin Desktop Environment
+License:        GPLv3
+URL:            https://github.com/linuxdeepin/deepin-icon-theme
+Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildRequires:  /usr/bin/python
+BuildRequires:  gtk-update-icon-cache
+BuildRequires:  xcursorgen
+BuildRequires:  fedora-logos
+Requires:       papirus-icon-theme
+Requires:       fedora-logos
+
+%description
+%{summary}.
+
+%prep
+%autosetup -p1
+# no such theme
+sed -i '/bloom-v20/d' Makefile
+
+%build
+%make_build
+
+%install
+make install-icons install-cursors DESTDIR=%{buildroot} PREFIX=%{_prefix}
+cp -a ./Sea ./bloom-classic ./bloom-classic-dark ./usr/share/icons/hicolor %{buildroot}%{_datadir}/icons
+for theme in %{themes}; do
+    for dir in %{buildroot}%{_datadir}/icons/$theme/places/*; do
+        size=$(basename $dir)
+        if [ -f %{_datadir}/icons/hicolor/${size}x${size}/places/%{start_logo}.png ]; then
+            ln -sf ../../../hicolor/${size}x${size}/places/%{start_logo}.png $dir
+        elif [ -f %{_datadir}/icons/hicolor/${size}/places/%{start_logo}.svg ]; then
+            ln -sf ../../../hicolor/${size}/places/%{start_logo}.svg $dir
+        fi
+    done
+    touch %{buildroot}%{_datadir}/icons/$theme/icon-theme.cache
+done
+
+%post
+for theme in %{themes}; do
+  touch --no-create %{_datadir}/icons/$theme &>/dev/null || :
+done
+
+%postun
+if [ $1 -eq 0 ] ; then
+  for theme in %{themes}; do
+    touch --no-create %{_datadir}/icons/$theme &>/dev/null
+    /usr/bin/gtk-update-icon-cache %{_datadir}/icons/$theme &>/dev/null || :
+  done
+fi
+
+%posttrans
+for theme in %{themes}; do
+  /usr/bin/gtk-update-icon-cache %{_datadir}/icons/$theme &>/dev/null || :
+done
+
+%files
+%license LICENSE
+%{_datadir}/icons/hicolor/*/status/*.svg
+%{_datadir}/icons/hicolor/*/apps/*.svg
+%{_datadir}/icons/bloom-dark/
+%{_datadir}/icons/bloom/
+%{_datadir}/icons/bloom-classic/
+%{_datadir}/icons/bloom-classic-dark/
+%{_datadir}/icons/Sea/
+%ghost %{_datadir}/icons/*/icon-theme.cache
+
+%changelog


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log: Initial packit setup
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>