### PR TITLE
chore: bump version to 2023.11.16

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-icon-theme (2023.11.16) unstable; urgency=medium
+
+  * fix: can not find existed
+  * chore: Modify icon name
+
+ -- bluesky <chenchongbiao@deepin.org>  Thu, 16 Nov 2023 10:15:48 +0800
+
 deepin-icon-theme (2023.04.03) unstable; urgency=medium
 
   * add bloom status icons


### PR DESCRIPTION
fix: can not find existed
chore: Modify icon name linuxdeepin/developer-center/issues/6099

Log: bump version