### PR TITLE
fix: 090 battery icon wrong in vintage

### DIFF
--- a/vintage/status/20/battery-090-symbolic-dark.svg
+++ b/vintage/status/20/battery-090-symbolic-dark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
   <g fill="none" fill-rule="evenodd">
     <polygon fill="#3ACB00" points="2 6 16 6 16 14 2 14"/>
-    <path fill="#000" fill-rule="nonzero" d="M19,4 L0,4 L0,16 L19,16 L19,12 L20,12 L20,8 L19,8 L19,4 Z M18,5 L18,15 L1,15 L1,5 L18,5 Z"/>
+    <path fill="#FFF" fill-rule="nonzero" d="M19,4 L-5.68434189e-14,4 L-5.68434189e-14,16 L19,16 L19,12 L20,12 L20,8 L19,8 L19,4 Z M18,5 L18,15 L1,15 L1,5 L18,5 Z"/>
   </g>
 </svg>

--- a/vintage/status/20/battery-090-symbolic.svg
+++ b/vintage/status/20/battery-090-symbolic.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
   <g fill="none" fill-rule="evenodd">
     <polygon fill="#3ACB00" points="2 6 16 6 16 14 2 14"/>
-    <path fill="#FFF" fill-rule="nonzero" d="M19,4 L-5.68434189e-14,4 L-5.68434189e-14,16 L19,16 L19,12 L20,12 L20,8 L19,8 L19,4 Z M18,5 L18,15 L1,15 L1,5 L18,5 Z"/>
+    <path fill="#000" fill-rule="nonzero" d="M19,4 L0,4 L0,16 L19,16 L19,12 L20,12 L20,8 L19,8 L19,4 Z M18,5 L18,15 L1,15 L1,5 L18,5 Z"/>
   </g>
 </svg>


### PR DESCRIPTION
Log:
Issue: https://github.com/linuxdeepin/developer-center/issues/6348