### PR TITLE
fix: drop "px" suffix, remove nonexistent dirs

### DIFF
--- a/bloom-classic-dark/index.theme
+++ b/bloom-classic-dark/index.theme
@@ -51,11 +51,6 @@ Size=16
 Context=MimeTypes
 Type=Fixed
 
-[mimetypes/22]
-Size=22
-Context=MimeTypes
-Type=Fixed
-
 [mimetypes/24]
 Size=24
 Context=MimeTypes

--- a/bloom-classic/index.theme
+++ b/bloom-classic/index.theme
@@ -54,7 +54,7 @@ Type=Fixed
 Size=24
 Context=Emblems
 Type=Scalable
-MinSize=12px
+MinSize=12
 MaxSize=128
 
 [devices/16]
@@ -104,11 +104,6 @@ MaxSize=512
 
 [mimetypes/16]
 Size=16
-Context=MimeTypes
-Type=Fixed
-
-[mimetypes/22]
-Size=22
 Context=MimeTypes
 Type=Fixed
 

--- a/bloom-dark/index.theme
+++ b/bloom-dark/index.theme
@@ -79,7 +79,7 @@ Type=Fixed
 Size=24
 Context=Emblems
 Type=Scalable
-MinSize=12px
+MinSize=12
 MaxSize=128
 
 [devices/16]
@@ -129,11 +129,6 @@ MaxSize=512
 
 [mimetypes/16]
 Size=16
-Context=MimeTypes
-Type=Fixed
-
-[mimetypes/22]
-Size=22
 Context=MimeTypes
 Type=Fixed
 

--- a/bloom/index.theme
+++ b/bloom/index.theme
@@ -81,7 +81,7 @@ Type=Fixed
 Size=24
 Context=Emblems
 Type=Scalable
-MinSize=12px
+MinSize=12
 MaxSize=128
 
 [devices/16]
@@ -130,11 +130,6 @@ MaxSize=512
 
 [mimetypes/16]
 Size=16
-Context=MimeTypes
-Type=Fixed
-
-[mimetypes/22]
-Size=22
 Context=MimeTypes
 Type=Fixed
 

--- a/vintage/index.theme
+++ b/vintage/index.theme
@@ -73,7 +73,7 @@ Type=Fixed
 Size=24
 Context=Emblems
 Type=Scalable
-MinSize=12px
+MinSize=12
 MaxSize=128
 
 [devices/16]
@@ -118,11 +118,6 @@ MaxSize=512
 
 [mimetypes/16]
 Size=16
-Context=MimeTypes
-Type=Fixed
-
-[mimetypes/22]
-Size=22
 Context=MimeTypes
 Type=Fixed
 


### PR DESCRIPTION
This improves icon theme specification compliance.