### PR TITLE
chore: remove  papirus-icon-theme dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,6 @@ Package: deepin-icon-theme
 Architecture: all
 Depends:
  ${misc:Depends},
- papirus-icon-theme,
 Conflicts: deepin-cursor-theme
 Description: Deepin Icons
  This package is DeepinIconTheme 


### PR DESCRIPTION
Cancel the pre installation of papirus-icon-theme

Issue: https://github.com/linuxdeepin/developer-center/issues/9024