### PR TITLE
Revert "chore: remove papirus-icon-theme dependency"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Package: deepin-icon-theme
 Architecture: all
 Depends:
  ${misc:Depends},
+ papirus-icon-theme,
 Conflicts: deepin-cursor-theme
 Description: Deepin Icons
  This package is DeepinIconTheme 


### PR DESCRIPTION
This reverts commit 18812b61c08199c3c553712f08c6d41b02d134d7.

Issue: https://github.com/linuxdeepin/developer-center/issues/9438