### PR TITLE
fix: some app icons are small on high-res screen

### DIFF
--- a/bloom/index.theme
+++ b/bloom/index.theme
@@ -60,7 +60,9 @@ Type=Fixed
 [apps/96]
 Size=96
 Context=Applications
-Type=Fixed
+Type=Scalable
+MinSize=96
+MaxSize=256
 
 [apps/128]
 Size=128

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-icon-theme (2024.07.10) unstable; urgency=medium
+
+  * Fix: some app icons are small on high-res screen
+
+ -- Yutao Meng <mengyutao@deepin.org>  Wed, 10 Jul 2024 11:17:03 +0800
+
 deepin-icon-theme (2024.07.02) unstable; urgency=medium
 
   * Revert "chore: remove papirus-icon-theme dependency"


### PR DESCRIPTION
Issue: https://github.com/linuxdeepin/developer-center/issues/9572
Log: some app icons are small on high-res screen