### PR TITLE
chore: remove unnecessary quotation marks from the Name field

### DIFF
--- a/bloom-dark/cursor.theme
+++ b/bloom-dark/cursor.theme
@@ -1,2 +1,2 @@
 [Icon Theme]
-Name="bloom-dark"
+Name=bloom-dark

--- a/bloom/cursor.theme
+++ b/bloom/cursor.theme
@@ -1,2 +1,2 @@
 [Icon Theme]
-Name="bloom"
+Name=bloom

--- a/vintage/cursor.theme
+++ b/vintage/cursor.theme
@@ -1,2 +1,2 @@
 [Icon Theme]
-Name="vintage"
+Name=vintage


### PR DESCRIPTION
The writing conventions for 'cursor.theme' are the same as those for 'index.theme'. XDG does not require the Name field in 'index.theme' to be enclosed in quotation marks

pms: BUG-286363
pms: BUG-286359

## Summary by Sourcery

Chores:
- Removed unnecessary quotation marks from the Name field in cursor.theme files.