### PR TITLE
chore: bump version to 2025.03.28

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-icon-theme (2025.03.28) unstable; urgency=medium
+
+  * chore: update bloom theme
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Tue, 13 May 2025 20:59:54 +0800
+
 deepin-icon-theme (2025.03.27) unstable; urgency=medium
 
   * chore: remove unnecessary quotation marks from the Name field


### PR DESCRIPTION
update changelog to 2025.03.28

## Summary by Sourcery

Chores:
- Bump Debian package version to 2025.03.28 in changelog