### PR TITLE
chore: bump version to 2025.12.04

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-icon-theme (2025.12.04) unstable; urgency=medium
+
+  * chore: delete deepin-license-activator
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 04 Dec 2025 19:39:53 +0800
+
 deepin-icon-theme (2025.9.11) unstable; urgency=medium
 
   * chore: remove papirus-icon-theme dependency


### PR DESCRIPTION
as title

Log: as title

## Summary by Sourcery

Chores:
- Prepare Debian changelog for the 2025.12.04 release version.