### PR TITLE
chore: update changelog to 2026.02.27

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-icon-theme (2026.02.27) unstable; urgency=medium
+
+  * feat: add more cursor sizes
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 27 Feb 2026 15:32:31 +0800
+
 deepin-icon-theme (2025.12.04) unstable; urgency=medium
 
   * chore: delete deepin-license-activator


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2026.02.27

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2026.02.27
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog to version 2026.02.27 targeting master.